### PR TITLE
Generate 12 digit uacs with no leading zeros when split

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Default ignored files
 /workspace.xml
 .idea
+app.yaml

--- a/uacgenerator/generator.go
+++ b/uacgenerator/generator.go
@@ -87,7 +87,12 @@ func NewUacGenerator(datastoreClient Datastore, uacKind string) *UacGenerator {
 }
 
 func (uacGenerator *UacGenerator) GenerateUac12() string {
-	return fmt.Sprintf("%012d", uacGenerator.Randomizer.Int63n(1e12))
+	var uac string
+	for i := 0; i < 3; i++ {
+		uacSegmant := uacGenerator.Randomizer.Int63n(9999 - 1000)
+		uac = fmt.Sprintf("%s%d", uac, uacSegmant+1000)
+	}
+	return uac
 }
 
 func (uacGenerator *UacGenerator) GenerateUac16() string {

--- a/uacgenerator/generator_test.go
+++ b/uacgenerator/generator_test.go
@@ -3,6 +3,7 @@ package uacgenerator_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"cloud.google.com/go/datastore"
 	"github.com/ONSDigital/blaise-uac-service/uacgenerator"
@@ -30,6 +31,14 @@ var _ = Describe("GenerateUac12", func() {
 			uac := uacGenerator.GenerateUac12()
 
 			Expect(uac).To(MatchRegexp(`^\d{12}$`))
+
+			var startIndex = 0
+			for i := 0; i < 3; i++ {
+				uacSegmant, _ := strconv.Atoi(uac[startIndex : startIndex+4])
+				Expect(uacSegmant).To(BeNumerically(">=", 1000))
+				Expect(uacSegmant).To(BeNumerically("<=", 9999))
+				startIndex = startIndex + 4
+			}
 		}
 	})
 })


### PR DESCRIPTION
This is a PoC to see what it looks like if we stick with the no leading zeros per UAC block as with the current nisra setup. Currently doing some maths to work out the entropy difference