### PR TITLE
Use keys only for admin delete, its far more memory efficient

### DIFF
--- a/uacgenerator/generator.go
+++ b/uacgenerator/generator.go
@@ -327,8 +327,7 @@ func (uacGenerator *UacGenerator) ValidateUACs(uacs []string) error {
 }
 
 func (uacGenerator *UacGenerator) AdminDelete(instrumentName string) error {
-	var instrumentUACs []*UacInfo
-	instrumentUACKeys, err := uacGenerator.DatastoreClient.GetAll(uacGenerator.Context, uacGenerator.instrumentQuery(instrumentName), &instrumentUACs)
+	instrumentUACKeys, err := uacGenerator.DatastoreClient.GetAll(uacGenerator.Context, uacGenerator.instrumentQuery(instrumentName).KeysOnly(), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When your into the hundreds of thousands or millions of records, a getall query is pretty horrible. We should probably split it out at some point to do the get part of the delete multi threaded. But given its a hidden endpoint anyway this cuts down the overhead significantly